### PR TITLE
Feat/add role management

### DIFF
--- a/prisma/migrations/20250201152322_change_type_role_name/migration.sql
+++ b/prisma/migrations/20250201152322_change_type_role_name/migration.sql
@@ -1,0 +1,15 @@
+/*
+  Warnings:
+
+  - Changed the type of `name` on the `roles` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+
+*/
+-- AlterTable
+ALTER TABLE "roles" DROP COLUMN "name",
+ADD COLUMN     "name" TEXT NOT NULL;
+
+-- DropEnum
+DROP TYPE "UserRole";
+
+-- CreateIndex
+CREATE UNIQUE INDEX "roles_name_key" ON "roles"("name");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -13,11 +13,6 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
-enum UserRole {
-  USER
-  ADMIN
-}
-
 enum TokenType {
   ACCESS
   REFRESH
@@ -61,7 +56,7 @@ model User {
 
 model Role {
   id          Int      @id @default(autoincrement())
-  name        UserRole @unique
+  name        String @unique
   description String?  @db.Text
 
   permissions Permission[]

--- a/prisma/seeds/permissions.ts
+++ b/prisma/seeds/permissions.ts
@@ -1,10 +1,10 @@
 /* eslint-disable @typescript-eslint/no-misused-promises */
-import { PrismaClient, UserRole, Action } from '@prisma/client';
+import { PrismaClient, Action } from '@prisma/client';
 
 const prisma = new PrismaClient();
 
 const adminRoleObj = {
-  name: UserRole.ADMIN,
+  name: 'Admin',
   description: 'Administrator with full access',
   permissions: {
     create: [
@@ -18,7 +18,7 @@ const adminRoleObj = {
 };
 
 const userRoleObj = {
-  name: UserRole.USER,
+  name: 'User',
   description: 'Regular user with limited access',
   permissions: {
     create: [
@@ -38,7 +38,7 @@ const userRoleObj = {
 
 async function main() {
   const adminRole = await prisma.role.upsert({
-    where: { name: UserRole.ADMIN },
+    where: { name: 'Admin' },
     update: {
       ...adminRoleObj,
       permissions: {
@@ -76,7 +76,7 @@ async function main() {
   });
 
   const userRole = await prisma.role.upsert({
-    where: { name: UserRole.USER },
+    where: { name: 'User' },
     update: {
       ...userRoleObj,
       permissions: {

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -8,6 +8,8 @@ import { LoggerModule } from 'nestjs-pino';
 import { pinoLoggerConfig } from './config/pino-logger.config';
 import { CaslAbilityModule } from './casl/casl-ability.module';
 import { AuthModule } from './auth/auth.module';
+import { RolesModule } from './roles/roles.module';
+import { PermissionsModule } from './permissions/permissions.module';
 
 @Module({
   imports: [
@@ -28,6 +30,8 @@ import { AuthModule } from './auth/auth.module';
     UsersModule,
     CaslAbilityModule,
     AuthModule,
+    RolesModule,
+    PermissionsModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/auth/decorators/role-decorator.ts
+++ b/src/auth/decorators/role-decorator.ts
@@ -1,5 +1,4 @@
 import { SetMetadata } from '@nestjs/common';
-import { UserRole } from '@prisma/client';
 
 export const ROLES_KEY = 'roles';
-export const Roles = (...roles: UserRole[]) => SetMetadata(ROLES_KEY, roles);
+export const Roles = (...roles: string[]) => SetMetadata(ROLES_KEY, roles);

--- a/src/auth/dto/login.dto.ts
+++ b/src/auth/dto/login.dto.ts
@@ -4,7 +4,7 @@ import { IsEmail, IsNotEmpty, IsString } from 'class-validator';
 export class LoginDto {
   @IsEmail()
   @ApiProperty({
-    example: 'user@email.com',
+    example: 'admin@admin.com',
   })
   email: string;
 

--- a/src/auth/guards/role-auth.guard.ts
+++ b/src/auth/guards/role-auth.guard.ts
@@ -3,14 +3,13 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import { Injectable, CanActivate, ExecutionContext } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
-import { UserRole } from '@prisma/client';
 
 @Injectable()
 export class RolesGuard implements CanActivate {
   constructor(private reflector: Reflector) {}
 
   canActivate(context: ExecutionContext): boolean {
-    const requiredRoles = this.reflector.getAllAndOverride<UserRole[]>(
+    const requiredRoles = this.reflector.getAllAndOverride<Array<string>>(
       'roles',
       [context.getHandler(), context.getClass()],
     );

--- a/src/casl/casl-ability.factory.ts
+++ b/src/casl/casl-ability.factory.ts
@@ -43,14 +43,18 @@ export class CaslAbilityFactory {
         const action = permission.action.toLowerCase() as Actions;
 
         if (permission.conditions) {
-          can(action, permission.subject as any, permission.conditions);
+          can(
+            action,
+            permission.subject.toLocaleLowerCase() as any,
+            permission.conditions,
+          );
         } else {
-          can(action, permission.subject as any);
+          can(action, permission.subject.toLocaleLowerCase() as any);
         }
         if (permission.action === Action.MANAGE) {
           can(
             ['read', 'create', 'update', 'delete'] as Actions[],
-            permission.subject as any,
+            permission.subject.toLocaleLowerCase() as any,
           );
         }
       }

--- a/src/casl/casl-ability.factory.ts
+++ b/src/casl/casl-ability.factory.ts
@@ -8,20 +8,18 @@ import {
   InferSubjects,
   PureAbility,
 } from '@casl/ability';
-import { Permission, User } from '@prisma/client';
+import { Permission, PrismaClient, User } from '@prisma/client';
 import { Action } from '@prisma/client';
 
-export type Actions =
-  | Action
-  | 'manage'
-  | 'read'
-  | 'create'
-  | 'update'
-  | 'delete';
+export type Actions = 'manage' | 'read' | 'create' | 'update' | 'delete';
 
-export type Subjects =
-  | InferSubjects<'User' | 'Profile' | 'Role' | 'Permission'>
-  | 'all';
+type PrismaModelNames<T> = {
+  [K in keyof T]: T[K] extends { count: any } ? K : never;
+}[keyof T];
+
+type GetPrismaModels = PrismaModelNames<Omit<PrismaClient, symbol>>;
+
+export type Subjects = InferSubjects<GetPrismaModels> | 'all';
 
 export type AppAbility = PureAbility<[Actions, Subjects]>;
 

--- a/src/casl/decorators/check-policies.decorator.ts
+++ b/src/casl/decorators/check-policies.decorator.ts
@@ -1,6 +1,5 @@
 import { SetMetadata } from '@nestjs/common';
 import { AppAbility } from '../casl-ability.factory';
-import { Action } from '@prisma/client';
 
 export interface IPolicyHandler {
   handle(ability: AppAbility): boolean;
@@ -17,6 +16,6 @@ export const CheckPolicies = (...handlers: PolicyHandler[]) =>
 
 export class ReadUserPolicyHandler implements IPolicyHandler {
   handle(ability: AppAbility) {
-    return ability.can(Action.READ, 'User');
+    return ability.can('read', 'user');
   }
 }

--- a/src/common/decorators/api-response.decorator.ts
+++ b/src/common/decorators/api-response.decorator.ts
@@ -5,8 +5,9 @@ import { ApiResponse, ApiResponsePaginated } from '../dtos/api-response.dto';
 export const ApiResponseDecorator = <TModel extends Type<any>>(
   model: TModel,
   isArray: boolean = false,
+  isPaginated: boolean = false,
 ) => {
-  const ResponseClass = isArray ? ApiResponsePaginated : ApiResponse;
+  const ResponseClass = isPaginated ? ApiResponsePaginated : ApiResponse;
   return applyDecorators(
     ApiExtraModels(ResponseClass, model),
     ApiOkResponse({

--- a/src/permissions/decorators/validate-subject.decorator.ts
+++ b/src/permissions/decorators/validate-subject.decorator.ts
@@ -1,0 +1,32 @@
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+import {
+  registerDecorator,
+  ValidationOptions,
+  ValidationArguments,
+} from 'class-validator';
+import { PrismaClient } from '@prisma/client';
+
+export function IsValidSubject(validationOptions?: ValidationOptions) {
+  return function (object: object, propertyName: string) {
+    registerDecorator({
+      name: 'isValidSubject',
+      target: object.constructor,
+      propertyName: propertyName,
+      options: validationOptions,
+      validator: {
+        validate(value: string) {
+          const prismaModels = Object.keys(new PrismaClient())
+            .filter(
+              (key) => typeof new PrismaClient()[key]?.count === 'function',
+            )
+            .map((key) => key.toLowerCase());
+
+          return value === 'all' || prismaModels.includes(value.toLowerCase());
+        },
+        defaultMessage(args: ValidationArguments) {
+          return `${args.property} must be a valid Prisma model name or 'all'`;
+        },
+      },
+    });
+  };
+}

--- a/src/permissions/dto/create-permission.dto.ts
+++ b/src/permissions/dto/create-permission.dto.ts
@@ -1,0 +1,28 @@
+import { IsEnum, IsString, IsOptional, IsObject } from 'class-validator';
+import { Action } from '@prisma/client';
+import { ApiProperty } from '@nestjs/swagger';
+import { IsValidSubject } from '../decorators/validate-subject.decorator';
+import { Subjects } from 'src/casl/casl-ability.factory';
+
+export class CreatePermissionDto {
+  @IsEnum(Action)
+  @ApiProperty({ enum: Action })
+  action: Action;
+
+  @IsString()
+  @ApiProperty({
+    type: String,
+  })
+  @IsValidSubject()
+  subject: Subjects;
+
+  @IsObject()
+  @IsOptional()
+  @ApiProperty()
+  conditions?: Record<string, any>;
+
+  @IsString()
+  @IsOptional()
+  @ApiProperty()
+  reason?: string;
+}

--- a/src/permissions/dto/permission.dto.ts
+++ b/src/permissions/dto/permission.dto.ts
@@ -1,0 +1,23 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { $Enums } from '@prisma/client';
+import { JsonValue } from '@prisma/client/runtime/library';
+
+export class PermissionDto {
+  @ApiProperty({ type: Number })
+  id: number;
+
+  @ApiProperty({ enum: $Enums.Action })
+  action: $Enums.Action;
+
+  @ApiProperty()
+  subject: string;
+
+  @ApiProperty({ type: Object })
+  conditions: JsonValue;
+
+  @ApiProperty({
+    type: String,
+    nullable: true,
+  })
+  reason: string | null;
+}

--- a/src/permissions/permissions.controller.ts
+++ b/src/permissions/permissions.controller.ts
@@ -1,0 +1,115 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Patch,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiCreatedResponse,
+  ApiOperation,
+  ApiResponse,
+  ApiTags,
+  getSchemaPath,
+} from '@nestjs/swagger';
+import { Roles } from 'src/auth/decorators/role-decorator';
+import { JwtAuthGuard } from 'src/auth/guards/jwt-auth.guard';
+import { RolesGuard } from 'src/auth/guards/role-auth.guard';
+import { PoliciesGuard } from 'src/casl/guards/policies.guard';
+import { CheckPolicies } from 'src/casl/decorators/check-policies.decorator';
+import { AppAbility } from 'src/casl/casl-ability.factory';
+import { ApiResponseDecorator } from 'src/common/decorators/api-response.decorator';
+import { ApiErrorResponseDecorator } from 'src/common/decorators/api-error-response.decorator';
+import { SucessResponse } from 'src/common/utils/response.util';
+import { PermissionsService } from './permissions.service';
+import { PermissionDto } from './dto/permission.dto';
+import { CreatePermissionDto } from './dto/create-permission.dto';
+
+@ApiTags('Permissions')
+@Controller('permissions')
+@Roles('Admin', 'User')
+@UseGuards(JwtAuthGuard, RolesGuard, PoliciesGuard)
+export class PermissionsController {
+  constructor(private readonly permissionsService: PermissionsService) {}
+
+  @Post()
+  @CheckPolicies((ability: AppAbility) => ability.can('create', 'permission'))
+  @ApiOperation({ summary: 'Create a permission' })
+  @ApiBearerAuth('JWT-auth')
+  @ApiResponseDecorator(PermissionDto)
+  @ApiErrorResponseDecorator({
+    validation: true,
+    badRequest: true,
+    notFound: true,
+    forbidden: true,
+    unauthorized: true,
+  })
+  @ApiCreatedResponse({
+    schema: {
+      allOf: [{ $ref: getSchemaPath(ApiResponse) }],
+      properties: { data: { $ref: getSchemaPath(PermissionDto) } },
+    },
+  })
+  async create(@Body() permissionDto: CreatePermissionDto) {
+    const permission = await this.permissionsService.create(permissionDto);
+    return SucessResponse('Success to create role', 201, permission);
+  }
+
+  @Get()
+  @CheckPolicies((ability: AppAbility) => ability.can('read', 'permission'))
+  @ApiOperation({ summary: 'Get all permissions' })
+  @ApiBearerAuth('JWT-auth')
+  @ApiResponseDecorator(PermissionDto, true)
+  @ApiErrorResponseDecorator({
+    validation: true,
+    badRequest: true,
+    notFound: true,
+    forbidden: true,
+    unauthorized: true,
+  })
+  async findAll() {
+    const permissions = await this.permissionsService.findAll();
+    return SucessResponse('Success to get all permissions', 200, permissions);
+  }
+
+  @Patch(':id')
+  @CheckPolicies((ability: AppAbility) => ability.can('update', 'permission'))
+  @ApiOperation({ summary: 'Update a permission' })
+  @ApiBearerAuth('JWT-auth')
+  @ApiResponseDecorator(PermissionDto)
+  @ApiErrorResponseDecorator({
+    validation: true,
+    badRequest: true,
+    notFound: true,
+    forbidden: true,
+    unauthorized: true,
+  })
+  async update(
+    @Param('id') id: number,
+    @Body() permissionDto: CreatePermissionDto,
+  ) {
+    const permission = await this.permissionsService.update(id, permissionDto);
+    return SucessResponse('Success to update role', 200, permission);
+  }
+
+  @Delete(':id')
+  @CheckPolicies((ability: AppAbility) => ability.can('delete', 'permission'))
+  @ApiOperation({ summary: 'Delete a permissions' })
+  @ApiBearerAuth('JWT-auth')
+  @ApiResponseDecorator(Boolean)
+  @ApiErrorResponseDecorator({
+    validation: true,
+    badRequest: true,
+    notFound: true,
+    forbidden: true,
+    unauthorized: true,
+  })
+  async delete(@Param('id') id: number) {
+    await this.permissionsService.delete(id);
+    return SucessResponse('Success to delete permissions', 200, true);
+  }
+}

--- a/src/permissions/permissions.module.ts
+++ b/src/permissions/permissions.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { PrismaModule } from '../prisma/prisma.module';
+import { PermissionsController } from './permissions.controller';
+import { PermissionsService } from './permissions.service';
+import { CaslAbilityModule } from 'src/casl/casl-ability.module';
+
+@Module({
+  imports: [PrismaModule, CaslAbilityModule],
+  controllers: [PermissionsController],
+  providers: [PermissionsService],
+  exports: [PermissionsService],
+})
+export class PermissionsModule {}

--- a/src/permissions/permissions.service.ts
+++ b/src/permissions/permissions.service.ts
@@ -1,0 +1,97 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
+import { PrismaQueryHelperService } from 'src/prisma/query-helper.service';
+import { CreatePermissionDto } from './dto/create-permission.dto';
+import { PermissionDto } from './dto/permission.dto';
+
+@Injectable()
+export class PermissionsService {
+  constructor(
+    @InjectPinoLogger(PermissionsService.name)
+    private readonly logger: PinoLogger,
+    private readonly prisma: PrismaService,
+    private readonly queryHelper: PrismaQueryHelperService,
+  ) {}
+
+  extendedPrisma = this.prisma.$extends(this.queryHelper.softDeleteExtension);
+
+  async findAll(): Promise<PermissionDto[]> {
+    this.logger.info('Find all permissions');
+    const permissions = await this.prisma.permission.findMany();
+    return permissions;
+  }
+
+  async findByIds(ids: number[]): Promise<PermissionDto[]> {
+    this.logger.info('Find permissions by ids');
+    const permissions = await this.prisma.permission.findMany({
+      where: {
+        id: {
+          in: ids,
+        },
+      },
+    });
+    return permissions;
+  }
+
+  async findOne(id: number): Promise<PermissionDto> {
+    this.logger.info('Find one permission');
+    const permission = await this.prisma.permission.findUnique({
+      where: { id },
+    });
+    if (!permission) {
+      throw new NotFoundException(['Permission not found']);
+    }
+    return permission;
+  }
+
+  async create(dto: CreatePermissionDto): Promise<PermissionDto> {
+    this.logger.info('Create permission');
+    const permission = await this.prisma.permission.findUnique({
+      where: {
+        action_subject: {
+          subject: dto.subject,
+          action: dto.action,
+        },
+      },
+    });
+
+    if (permission) {
+      throw new NotFoundException(['Permission already exists']);
+    }
+
+    const newPermission = await this.prisma.permission.create({
+      data: {
+        action: dto.action,
+        subject: dto.subject,
+        conditions: dto.conditions,
+        reason: dto.reason,
+      },
+    });
+    return newPermission;
+  }
+
+  async update(id: number, dto: CreatePermissionDto): Promise<PermissionDto> {
+    this.logger.info('Update permission');
+    await this.findOne(id);
+    const permission = await this.prisma.permission.update({
+      where: { id },
+      data: {
+        action: dto.action,
+        subject: dto.subject,
+        conditions: dto.conditions,
+        reason: dto.reason,
+      },
+    });
+    return permission;
+  }
+
+  async delete(id: number): Promise<boolean> {
+    this.logger.info('Delete permission');
+    await this.findOne(id);
+    await this.prisma.permission.delete({
+      where: { id },
+    });
+    return true;
+  }
+}

--- a/src/roles/dto/assign-permission.dto.ts
+++ b/src/roles/dto/assign-permission.dto.ts
@@ -1,0 +1,10 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsArray, ArrayNotEmpty, IsNumber } from 'class-validator';
+
+export class AssignPermissionsDto {
+  @IsArray()
+  @ArrayNotEmpty()
+  @IsNumber({}, { each: true })
+  @ApiProperty({ type: [Number] })
+  permissionIds: number[];
+}

--- a/src/roles/dto/create-role.dto.ts
+++ b/src/roles/dto/create-role.dto.ts
@@ -1,0 +1,21 @@
+import { IsString, IsOptional, IsArray } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class CreateRoleDto {
+  @IsString()
+  @ApiProperty()
+  name: string;
+
+  @IsString()
+  @IsOptional()
+  @ApiProperty()
+  description?: string;
+
+  @IsArray({
+    each: true,
+  })
+  @ApiProperty({
+    type: [Number],
+  })
+  permissions: number[];
+}

--- a/src/roles/dto/role.dto.ts
+++ b/src/roles/dto/role.dto.ts
@@ -1,0 +1,20 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { PermissionDto } from 'src/permissions/dto/permission.dto';
+
+export class RoleDto {
+  @ApiProperty()
+  id: number;
+
+  @ApiProperty()
+  name: string;
+
+  @ApiProperty({
+    type: String,
+  })
+  description: string | null;
+
+  @ApiProperty({
+    type: [PermissionDto],
+  })
+  permissions: PermissionDto[];
+}

--- a/src/roles/dto/update-role.dto.ts
+++ b/src/roles/dto/update-role.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateRoleDto } from './create-role.dto';
+
+export class UpdateRoleDto extends PartialType(CreateRoleDto) {}

--- a/src/roles/roles.controller.ts
+++ b/src/roles/roles.controller.ts
@@ -1,0 +1,177 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Patch,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiCreatedResponse,
+  ApiOperation,
+  ApiResponse,
+  ApiTags,
+  getSchemaPath,
+} from '@nestjs/swagger';
+import { Roles } from 'src/auth/decorators/role-decorator';
+import { JwtAuthGuard } from 'src/auth/guards/jwt-auth.guard';
+import { RolesGuard } from 'src/auth/guards/role-auth.guard';
+import { PoliciesGuard } from 'src/casl/guards/policies.guard';
+import { RolesService } from './roles.service';
+import { CheckPolicies } from 'src/casl/decorators/check-policies.decorator';
+import { AppAbility } from 'src/casl/casl-ability.factory';
+import { ApiResponseDecorator } from 'src/common/decorators/api-response.decorator';
+import { RoleDto } from './dto/role.dto';
+import { ApiErrorResponseDecorator } from 'src/common/decorators/api-error-response.decorator';
+import { CreateRoleDto } from './dto/create-role.dto';
+import { SucessResponse } from 'src/common/utils/response.util';
+import { UpdateRoleDto } from './dto/update-role.dto';
+import { AssignPermissionsDto } from './dto/assign-permission.dto';
+
+@ApiTags('Roles')
+@Controller('roles')
+@Roles('Admin', 'User')
+@UseGuards(JwtAuthGuard, RolesGuard, PoliciesGuard)
+export class RolesController {
+  constructor(private readonly rolesService: RolesService) {}
+
+  @Post()
+  @CheckPolicies((ability: AppAbility) => ability.can('create', 'role'))
+  @ApiOperation({ summary: 'Create a role' })
+  @ApiBearerAuth('JWT-auth')
+  @ApiResponseDecorator(RoleDto)
+  @ApiErrorResponseDecorator({
+    validation: true,
+    badRequest: true,
+    notFound: true,
+    forbidden: true,
+    unauthorized: true,
+  })
+  @ApiCreatedResponse({
+    schema: {
+      allOf: [{ $ref: getSchemaPath(ApiResponse) }],
+      properties: { data: { $ref: getSchemaPath(RoleDto) } },
+    },
+  })
+  async create(@Body() createRoleDto: CreateRoleDto) {
+    const role = await this.rolesService.create(createRoleDto);
+    return SucessResponse('Success to create role', 201, role);
+  }
+
+  @Get()
+  @CheckPolicies((ability: AppAbility) => ability.can('read', 'role'))
+  @ApiOperation({ summary: 'Get all roles' })
+  @ApiBearerAuth('JWT-auth')
+  @ApiResponseDecorator(RoleDto, true)
+  @ApiErrorResponseDecorator({
+    validation: true,
+    badRequest: true,
+    notFound: true,
+    forbidden: true,
+    unauthorized: true,
+  })
+  async findAll() {
+    const roles = await this.rolesService.findAll();
+    return SucessResponse('Success to get all roles', 200, roles);
+  }
+
+  @Get(':id')
+  @CheckPolicies((ability: AppAbility) => ability.can('read', 'role'))
+  @ApiOperation({ summary: 'Get a role' })
+  @ApiBearerAuth('JWT-auth')
+  @ApiResponseDecorator(RoleDto)
+  @ApiErrorResponseDecorator({
+    validation: true,
+    badRequest: true,
+    notFound: true,
+    forbidden: true,
+    unauthorized: true,
+  })
+  async findOne(@Param('id') id: number) {
+    const role = await this.rolesService.findOne(id);
+    return SucessResponse('Success to get a role', 200, role);
+  }
+
+  @Patch(':id')
+  @CheckPolicies((ability: AppAbility) => ability.can('update', 'role'))
+  @ApiOperation({ summary: 'Update a role' })
+  @ApiBearerAuth('JWT-auth')
+  @ApiResponseDecorator(RoleDto)
+  @ApiErrorResponseDecorator({
+    validation: true,
+    badRequest: true,
+    notFound: true,
+    forbidden: true,
+    unauthorized: true,
+  })
+  async update(@Param('id') id: number, @Body() updateRoleDto: UpdateRoleDto) {
+    const role = await this.rolesService.update(id, updateRoleDto);
+    return SucessResponse('Success to update a role', 200, role);
+  }
+
+  @Delete(':id')
+  @CheckPolicies((ability: AppAbility) => ability.can('delete', 'role'))
+  @ApiOperation({ summary: 'Delete a role' })
+  @ApiBearerAuth('JWT-auth')
+  @ApiResponseDecorator(Boolean)
+  @ApiErrorResponseDecorator({
+    validation: true,
+    badRequest: true,
+    notFound: true,
+    forbidden: true,
+    unauthorized: true,
+  })
+  async remove(@Param('id') id: number) {
+    await this.rolesService.remove(id);
+    return SucessResponse('Success to delete a role', 200, true);
+  }
+
+  @Post('assign/:userId/:roleId')
+  @CheckPolicies(
+    (ability: AppAbility) =>
+      ability.can('update', 'role') && ability.can('update', 'user'),
+  )
+  @ApiOperation({ summary: 'Delete a role' })
+  @ApiBearerAuth('JWT-auth')
+  @ApiResponseDecorator(RoleDto)
+  @ApiErrorResponseDecorator({
+    validation: true,
+    badRequest: true,
+    notFound: true,
+    forbidden: true,
+    unauthorized: true,
+  })
+  async assignToUser(
+    @Param('userId') userId: number,
+    @Param('roleId') roleId: number,
+  ) {
+    const user = await this.rolesService.assignToUser(userId, roleId);
+    return SucessResponse('Success to assign a role to user', 200, user);
+  }
+
+  @Patch(':id/permissions')
+  @CheckPolicies((ability: AppAbility) => ability.can('update', 'role'))
+  @ApiOperation({ summary: 'Delete a role' })
+  @ApiBearerAuth('JWT-auth')
+  @ApiResponseDecorator(RoleDto)
+  @ApiErrorResponseDecorator({
+    validation: true,
+    badRequest: true,
+    notFound: true,
+    forbidden: true,
+    unauthorized: true,
+  })
+  async assignPermissions(
+    @Param('id') id: number,
+    @Body() dto: AssignPermissionsDto,
+  ) {
+    const role = await this.rolesService.assignPermissions(
+      id,
+      dto.permissionIds,
+    );
+    return SucessResponse('Success to assign permissions to role', 200, role);
+  }
+}

--- a/src/roles/roles.module.ts
+++ b/src/roles/roles.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { PrismaModule } from '../prisma/prisma.module';
+import { RolesController } from './roles.controller';
+import { RolesService } from './roles.service';
+import { UsersModule } from 'src/users/users.module';
+import { CaslAbilityModule } from 'src/casl/casl-ability.module';
+
+@Module({
+  imports: [PrismaModule, UsersModule, CaslAbilityModule],
+  controllers: [RolesController],
+  providers: [RolesService],
+  exports: [RolesService],
+})
+export class RolesModule {}

--- a/src/roles/roles.service.ts
+++ b/src/roles/roles.service.ts
@@ -1,0 +1,172 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
+import { PrismaQueryHelperService } from 'src/prisma/query-helper.service';
+import { CreateRoleDto } from './dto/create-role.dto';
+import { UsersService } from 'src/users/users.service';
+import { UserDto } from 'src/users/dto/user.dto';
+import { RoleDto } from './dto/role.dto';
+import { UpdateRoleDto } from './dto/update-role.dto';
+
+@Injectable()
+export class RolesService {
+  constructor(
+    @InjectPinoLogger(RolesService.name)
+    private readonly logger: PinoLogger,
+    private readonly prisma: PrismaService,
+    private readonly userService: UsersService,
+    private readonly queryHelper: PrismaQueryHelperService,
+  ) {}
+
+  extendedPrisma = this.prisma.$extends(this.queryHelper.softDeleteExtension);
+
+  async create(data: CreateRoleDto): Promise<RoleDto> {
+    this.logger.info('Create role');
+
+    const role = await this.prisma.role.create({
+      data: {
+        name: data.name,
+        description: data.description,
+        permissions: {
+          connect: data.permissions.map((id) => ({ id })),
+        },
+      },
+      include: {
+        permissions: true,
+      },
+    });
+
+    return role;
+  }
+
+  async findAll(): Promise<RoleDto[]> {
+    this.logger.info('Find all roles');
+
+    const roles = await this.prisma.role.findMany({
+      include: {
+        permissions: true,
+      },
+    });
+
+    return roles;
+  }
+
+  async findOne(id: number): Promise<RoleDto> {
+    this.logger.info('Find one role');
+
+    const role = await this.prisma.role.findUnique({
+      where: { id },
+      include: {
+        permissions: true,
+      },
+    });
+
+    if (!role) {
+      throw new NotFoundException(['Role not found']);
+    }
+
+    return role;
+  }
+
+  async update(id: number, data: UpdateRoleDto): Promise<RoleDto> {
+    this.logger.info('Update role');
+
+    await this.findOne(id);
+
+    const role = await this.prisma.role.update({
+      where: { id },
+      data: {
+        name: data.name,
+        description: data.description,
+        permissions: {
+          connect: data.permissions?.map((id) => ({ id })),
+        },
+      },
+      include: {
+        permissions: true,
+      },
+    });
+
+    return role;
+  }
+
+  async remove(id: number): Promise<boolean> {
+    this.logger.info('Remove role');
+    await this.findOne(id);
+    await this.prisma.role.delete({
+      where: { id },
+    });
+    return true;
+  }
+
+  async assignPermissions(
+    roleId: number,
+    permissionIds: number[],
+  ): Promise<RoleDto> {
+    this.logger.info('Assign permissions to role');
+    await this.findOne(roleId);
+    const role = this.prisma.role.update({
+      where: { id: roleId },
+      data: {
+        permissions: {
+          set: permissionIds.map((id) => ({ id })),
+        },
+      },
+      include: {
+        permissions: true,
+      },
+    });
+    return role;
+  }
+
+  async assignToUser(userId: number, roleId: number): Promise<UserDto> {
+    this.logger.info('Assign role to user');
+
+    await this.userService.findOne(userId);
+    await this.findOne(roleId);
+
+    const updatedUser = await this.prisma.user.update({
+      where: { id: userId },
+      data: {
+        role: {
+          connect: {
+            id: roleId,
+          },
+        },
+      },
+      select: {
+        id: true,
+        uuid: true,
+        username: true,
+        email: true,
+        isVerified: true,
+        isActive: true,
+        lastLoginAt: true,
+        createdAt: true,
+        updatedAt: true,
+        deletedAt: true,
+        profile: {
+          select: {
+            id: true,
+            firstName: true,
+            lastName: true,
+            phoneNumber: true,
+            avatar: true,
+          },
+        },
+        role: {
+          select: {
+            id: true,
+            name: true,
+            description: true,
+          },
+          include: {
+            permissions: true,
+          },
+        },
+      },
+    });
+
+    return updatedUser;
+  }
+}

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -48,6 +48,8 @@ export class UsersController {
     validation: true,
     badRequest: true,
     notFound: true,
+    forbidden: true,
+    unauthorized: true,
   })
   @ApiCreatedResponse({
     schema: {
@@ -64,11 +66,13 @@ export class UsersController {
   @CheckPolicies((ability: AppAbility) => ability.can('read', 'user'))
   @ApiOperation({ summary: 'Get all users' })
   @ApiBearerAuth('JWT-auth')
-  @ApiResponseDecorator(UserDto, true)
+  @ApiResponseDecorator(UserDto, true, true)
   @ApiErrorResponseDecorator({
     validation: true,
     badRequest: true,
     notFound: true,
+    forbidden: true,
+    unauthorized: true,
   })
   async findAll(@Query() query: UserQueryDto) {
     const { data, meta } = await this.usersService.findAll(query);
@@ -84,6 +88,8 @@ export class UsersController {
     validation: true,
     badRequest: true,
     notFound: true,
+    forbidden: true,
+    unauthorized: true,
   })
   async findOne(@Param('id') id: number) {
     const user = await this.usersService.findOne(id);
@@ -99,6 +105,8 @@ export class UsersController {
     validation: true,
     badRequest: true,
     notFound: true,
+    forbidden: true,
+    unauthorized: true,
   })
   async update(@Param('id') id: number, @Body() updateUserDto: UpdateUserDto) {
     const user = await this.usersService.update(id, updateUserDto);
@@ -114,6 +122,8 @@ export class UsersController {
     validation: true,
     badRequest: true,
     notFound: true,
+    forbidden: true,
+    unauthorized: true,
   })
   async remove(@Param('id') id: number) {
     await this.usersService.remove(id);
@@ -129,6 +139,8 @@ export class UsersController {
     validation: true,
     badRequest: true,
     notFound: true,
+    forbidden: true,
+    unauthorized: true,
   })
   async hardRemove(@Param('id') id: number) {
     await this.usersService.hardRemove(id);
@@ -144,6 +156,8 @@ export class UsersController {
     validation: true,
     badRequest: true,
     notFound: true,
+    forbidden: true,
+    unauthorized: true,
   })
   async restore(@Param('id') id: number) {
     await this.usersService.restore(id);

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -34,13 +34,13 @@ import { Roles } from 'src/auth/decorators/role-decorator';
 
 @ApiTags('[ADMIN] Users')
 @Controller('users')
-@Roles('ADMIN')
+@Roles('Admin')
 @UseGuards(JwtAuthGuard, RolesGuard, PoliciesGuard)
 export class UsersController {
   constructor(private readonly usersService: UsersService) {}
 
   @Post()
-  @CheckPolicies((ability: AppAbility) => ability.can('create', 'User'))
+  @CheckPolicies((ability: AppAbility) => ability.can('create', 'user'))
   @ApiOperation({ summary: 'Create user' })
   @ApiBearerAuth('JWT-auth')
   @ApiResponseDecorator(UserDto)
@@ -61,7 +61,7 @@ export class UsersController {
   }
 
   @Get()
-  @CheckPolicies((ability: AppAbility) => ability.can('read', 'User'))
+  @CheckPolicies((ability: AppAbility) => ability.can('read', 'user'))
   @ApiOperation({ summary: 'Get all users' })
   @ApiBearerAuth('JWT-auth')
   @ApiResponseDecorator(UserDto, true)
@@ -76,7 +76,7 @@ export class UsersController {
   }
 
   @Get(':id')
-  @CheckPolicies((ability: AppAbility) => ability.can('read', 'User'))
+  @CheckPolicies((ability: AppAbility) => ability.can('read', 'user'))
   @ApiOperation({ summary: 'Get user' })
   @ApiBearerAuth('JWT-auth')
   @ApiResponseDecorator(UserDto)
@@ -91,7 +91,7 @@ export class UsersController {
   }
 
   @Patch(':id')
-  @CheckPolicies((ability: AppAbility) => ability.can('update', 'User'))
+  @CheckPolicies((ability: AppAbility) => ability.can('update', 'user'))
   @ApiOperation({ summary: 'Update user' })
   @ApiBearerAuth('JWT-auth')
   @ApiResponseDecorator(UserDto)
@@ -106,7 +106,7 @@ export class UsersController {
   }
 
   @Delete(':id')
-  @CheckPolicies((ability: AppAbility) => ability.can('delete', 'User'))
+  @CheckPolicies((ability: AppAbility) => ability.can('delete', 'user'))
   @ApiOperation({ summary: 'Remove user' })
   @ApiBearerAuth('JWT-auth')
   @ApiResponseDecorator(Boolean)
@@ -121,7 +121,7 @@ export class UsersController {
   }
 
   @Delete('hard-delete/:id')
-  @CheckPolicies((ability: AppAbility) => ability.can('delete', 'User'))
+  @CheckPolicies((ability: AppAbility) => ability.can('delete', 'user'))
   @ApiOperation({ summary: 'Hard delete user' })
   @ApiBearerAuth('JWT-auth')
   @ApiResponseDecorator(Boolean)
@@ -136,7 +136,7 @@ export class UsersController {
   }
 
   @Post('restore/:id')
-  @CheckPolicies((ability: AppAbility) => ability.can('delete', 'User'))
+  @CheckPolicies((ability: AppAbility) => ability.can('delete', 'user'))
   @ApiOperation({ summary: 'Restore user' })
   @ApiBearerAuth('JWT-auth')
   @ApiResponseDecorator(Boolean)


### PR DESCRIPTION
Here's a well-structured PR description based on your commits:
markdownCopy# Role and Permission Management System Enhancement

## Overview
This PR introduces comprehensive updates to the role and permission management system, focusing on dynamic role capabilities and CASL integration for more flexible access control.

## Key Changes
### Schema Updates
- Refactored role schema to support dynamic role naming instead of enum-based roles
- Added `isActive` status to both Role and Permission models
- Enhanced schema relationships for better role-permission mapping

### CASL Integration
- Updated CASL ability definitions to support dynamic namespace roles
- Implemented dynamic subject validation using Prisma model types
- Added custom decorator for subject validation in permission creation

### Role Management Features
- Implemented complete CRUD operations for role management
- Added endpoints for:
  - Role creation with dynamic naming
  - Permission assignment to roles
  - Role assignment to users
  - Role listing with associated permissions
  - Role deletion with proper cascading

### Permission Management
- Added permission management endpoints
- Implemented subject validation against Prisma models
- Added support for conditional permissions

## Technical Details
- Updated database schema to accommodate dynamic roles
- Implemented type-safe subject validation using Prisma model types
- Added proper error handling and validation
- Implemented proper separation of concerns between services

## Testing Instructions
1. Run migrations: `npx prisma migrate dev`
2. Test role creation with different names
3. Verify permission assignment to roles
4. Test CASL ability integration with new dynamic roles

## Related Issues
- Closes #[Issue number for role management]
- Addresses #[Issue number for permission system]

## Notes
- This update requires a database migration
- Existing roles may need to be migrated if updating from the enum-based system